### PR TITLE
Introduce compatibility code for 4.3.x

### DIFF
--- a/aca_preview/preview.py
+++ b/aca_preview/preview.py
@@ -16,11 +16,18 @@ import proseco
 from proseco.catalog import ACATable
 from proseco.core import StarsTable
 import proseco.characteristics as CHAR
+import proseco.characteristics_guide as GUIDE
 
 CACHE = {}
 VERSION = proseco.test(get_version=True)
 FILEDIR = Path(__file__).parent
 CATEGORIES = ('critical', 'warning', 'caution', 'info')
+
+
+# Fix characterstics compatibility issues between 4.3.x and 4.4+
+if not hasattr(CHAR, 'CCD'):
+    for attr in ('CCD', 'PIX_2_ARC', 'ARC_2_PIX'):
+        setattr(CHAR, attr, getattr(GUIDE, attr))
 
 
 def preview_load(load_name, outdir=None):

--- a/aca_preview/preview.py
+++ b/aca_preview/preview.py
@@ -64,6 +64,7 @@ def preview_load(load_name, outdir=None):
         aca.outdir = outdir
         aca.context = {}
         aca.messages = []
+        aca.set_stars_and_mask()
         aca.preview()
         acas.append(aca)
 
@@ -133,6 +134,24 @@ def get_summary_text(acas):
 
 
 class ACAReviewTable(ACATable):
+    def set_stars_and_mask(self):
+        """Set stars attribute for plotting.
+
+        This includes compatibility code to deal with somewhat-broken behavior
+        in 4.3.x where the base plot method is hard-coded to look at
+        ``acqs.stars`` and ``acqs.bad_stars``.
+
+        """
+        # Get stars from AGASC and set ``stars`` attribute
+        self.set_stars()
+
+        # Compatibility for 4.3.x before #221 (Make plot() method behave
+        # consistently and correctly)
+        if not hasattr(self, 'bad_stars_mask'):
+            acqs = self.acqs
+            acqs.stars = self.stars
+            _, acqs.bad_stars = acqs.get_acq_candidates(acqs.stars)
+
     def make_starcat_plot(self):
         plotname = f'cat{self.obsid}.png'
         outfile = self.outdir / plotname
@@ -141,12 +160,8 @@ class ACAReviewTable(ACATable):
         if outfile.exists():
             return
 
-        stars = StarsTable.from_agasc(self.att, date=self.date)
-        self.stars = stars
-
         fig = plt.figure(figsize=(4.5, 4))
         ax = fig.add_subplot(1, 1, 1)
-        self.acqs.stars
         self.plot(ax=ax)
         plt.tight_layout()
         fig.savefig(str(outfile))
@@ -157,7 +172,7 @@ class ACAReviewTable(ACATable):
 
         P2 = -np.log10(self.acqs.calc_p_safe())
         att = Quat(self.att)
-        self._base_repr_()
+        self._base_repr_()  # Hack to set default ``format`` for cols as needed
         catalog = '\n'.join(self.pformat(max_width=-1))
         self.acq_count = np.sum(self.acqs['p_acq'])
         self.guide_count = guide_count(self.guides['mag'], self.guides.t_ccd)

--- a/aca_preview/preview.py
+++ b/aca_preview/preview.py
@@ -24,7 +24,7 @@ FILEDIR = Path(__file__).parent
 CATEGORIES = ('critical', 'warning', 'caution', 'info')
 
 
-# Fix characterstics compatibility issues between 4.3.x and 4.4+
+# Fix characteristics compatibility issues between 4.3.x and 4.4+
 if not hasattr(CHAR, 'CCD'):
     for attr in ('CCD', 'PIX_2_ARC', 'ARC_2_PIX'):
         setattr(CHAR, attr, getattr(GUIDE, attr))


### PR DESCRIPTION
This takes a different approach from #6 and adds explicit compatibility code to make `aca_preview` work with both 4.3.x and master.

Tested with both and see no diffs in HTML output and star plots are generally similar, though the different versions do have different definitions of bad stars, so diffs are expected.  In particular 4.3.x marks all stars outside the allowed region for acq as bad, while master does not apply this spatial filtering so a reviewer can spot potential acq/guide stars to use for a roll change.

```
(ska3) neptune$ diff JAN2119A{,-4.3.2}/index.html
54c54
< Proseco version: 4.4-r515-b6ec6dd
---
> Proseco version: 4.3.2-r450-a1bf4fc
```
Closes #5 .