### PR TITLE
Ensure mag_err column is in ACAReviewTable and maxmag is not

### DIFF
--- a/aca_preview/preview.py
+++ b/aca_preview/preview.py
@@ -8,7 +8,7 @@ import io
 import re
 from pathlib import Path
 import pickle
-from itertools import combinations
+from itertools import combinations, chain
 
 import matplotlib
 matplotlib.use('Agg')
@@ -305,6 +305,16 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
             aca.acqs.obsid = num_obsid
             aca.guides.obsid = num_obsid
             aca.fids.obsid = num_obsid
+
+        if 'mag_err' not in aca.colnames:
+            # Add 'mag_err' column after 'mag' using 'mag_err' from guides and acqs
+            mag_errs = {entry['id']: entry['mag_err'] for entry in chain(aca.acqs, aca.guides)}
+            mag_errs = Column([mag_errs.get(id, 0.0) for id in aca['id']], name='mag_err')
+            aca.add_column(mag_errs, index=aca.colnames.index('mag') + 1)
+
+        # Don't want maxmag column
+        if 'maxmag' in aca.colnames:
+            del aca['maxmag']
 
         # Clean up some attributes so acq/guide report summary looks OK.  This should
         # be fixed upstream at some point.


### PR DESCRIPTION
This should be the right way to do this.

Closes #24 
Closes #25 
Closes #23

Testing:
- `python -m aca_preview.preview JAN2819P --roll-level=warning --report-level=critical`
- `python -m aca_preview.preview JAN2819P_select --roll-level=all --report-level=all` ("select" => obsids 48469, 21476.1, 48463, -1633)
```
In [2]: aca = get_aca_catalog(20603)
In [5]: from aca_preview.preview import *
In [6]: preview_load(load_name='one20603a', acas=[aca], obsids=['20603'])
In [8]: preview_load(load_name='one20603a', acas=[aca], obsids=['20603'], report_level='all', roll_level='all')
```
All gave expected results.

I was hoping to put in actual unit tests, but the pickle files even for the "select" set (which has a nice selection of obsids and warnings) is 800k and I'd rather not dump that in the repo.  It turns out gzipping saves a factor of 3, but it just got too complicated to rush.  So hopefully the documented testing here and independent tests will suffice.