### PR TITLE
Make 'all' level mean all

### DIFF
--- a/aca_preview/preview.py
+++ b/aca_preview/preview.py
@@ -157,13 +157,13 @@ def preview_load(load_name, *, outdir=None,
         aca.check_catalog()
 
         # If any aca.messages have category above report level then make report
-        if aca.messages >= report_level:
+        if report_level == 'all' or aca.messages >= report_level:
             try:
                 aca.make_report()
             except Exception as err:
                 aca.add_message('critical', text=f'Running make_report() failed: {err}')
 
-        if aca.messages >= roll_level:
+        if roll_level == 'all' or aca.messages >= roll_level:
             better_acas, better_stats = aca.get_better_catalogs()
             if len(better_acas) > 1:
                 aca.make_better_acas_report(better_acas, better_stats)


### PR DESCRIPTION
Fixes #25 

Testing:
```
(ska3-test) neptune$ time python -m aca_preview.preview JAN2819P_select --roll-level=all --report-level=all
Reading pickle file JAN2819P_select.pkl
Processing obsid 48469
  Creating HTML reports for obsid 48469
  Exploring roll options
Processing obsid 21476.1
  Creating HTML reports for obsid 21476.1
  Exploring roll options
Processing obsid 48464
  Creating HTML reports for obsid 48464
  Exploring roll options
Processing obsid -1633
  Creating HTML reports for obsid -1633
  Exploring roll options
Writing output review file JAN2819P_select_aca_preview/index.html
```
